### PR TITLE
Updating LongArrayTag ID from 62 to 12

### DIFF
--- a/src/main/java/net/darkhax/opennbt/tags/TagRegistry.java
+++ b/src/main/java/net/darkhax/opennbt/tags/TagRegistry.java
@@ -37,10 +37,10 @@ public class TagRegistry {
         register(9, ListTag.class);
         register(10, CompoundTag.class);
         register(11, IntArrayTag.class);
+        register(12, LongArrayTag.class);
         
         register(60, DoubleArrayTag.class);
         register(61, FloatArrayTag.class);
-        register(62, LongArrayTag.class);
         register(63, SerializableArrayTag.class);
         register(64, SerializableTag.class);
         register(65, ShortArrayTag.class);


### PR DESCRIPTION
To conform to the NBT specifications, the long array should have an ID of 12 (see https://wiki.vg/NBT)
Fix #2